### PR TITLE
docs(Nuxt3): use .client suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ export default defineComponent({
 </script>
 ```
 
-For Nuxt 3, create a file in `plugins/v-offline.ts`
+For Nuxt 3, create a file in `plugins/v-offline.client.ts`
 
 ```js
 import { VOffline } from 'v-offline';
@@ -111,20 +111,6 @@ import { VOffline } from 'v-offline';
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.component('VOffline', VOffline);
 });
-```
-
-then import the file in `nuxt.config.{j|t}s`:
-
-```js
-export default {
-  // ...
-  plugins: [
-    // ...
-    { src: '~/plugins/v-offline', mode: 'client' },
-    // ...
-  ],
-  // ...
-};
 ```
 
 ### Example


### PR DESCRIPTION
Hi, thanks for this package!

recently reading this docs for Nuxt 3, and notice we can use `.client` filename suffix and skip the import on nuxt.config since nuxt 3 already does the magic for the auto import plugins dir!

ref: https://nuxt.com/docs/guide/directory-structure/plugins
demo: https://stackblitz.com/edit/github-5lme1g?file=app.vue